### PR TITLE
Update utils.js to detect iPadOS

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,17 +5,7 @@ export const detectOS = (ua?: string): DetectOSResult => {
     ua = ua || navigator.userAgent
     const ipad = /(iPad).*OS\s([\d_]+)/.test(ua)
     const iphone = !ipad && /(iPhone\sOS)\s([\d_]+)/.test(ua)
-    const isIPadOs = window.AuthenticatorAssertionResponse === undefined
-    && window.AuthenticatorAttestationResponse === undefined
-    && window.AuthenticatorResponse === undefined
-    && window.Credential === undefined
-    && window.CredentialsContainer === undefined
-    && window.DeviceMotionEvent !== undefined
-    && window.DeviceOrientationEvent !== undefined
-    && navigator.maxTouchPoints === 5
-    && navigator.plugins.length === 0
-    && navigator.platform !== "iPhone"
-    && typeof navigator.standalone !== "undefined"
+    const isIPadOs = !!(navigator.userAgent.match(/(iPad)/) || (navigator.platform === "MacIntel" && typeof navigator.standalone !== "undefined"))
     
     const android = /(Android);?[\s/]+([\d.]+)?/.test(ua)
     const ios = iphone || ipad || isIPadOs

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,8 +5,20 @@ export const detectOS = (ua?: string): DetectOSResult => {
     ua = ua || navigator.userAgent
     const ipad = /(iPad).*OS\s([\d_]+)/.test(ua)
     const iphone = !ipad && /(iPhone\sOS)\s([\d_]+)/.test(ua)
+    const isIPadOs = window.AuthenticatorAssertionResponse === undefined
+    && window.AuthenticatorAttestationResponse === undefined
+    && window.AuthenticatorResponse === undefined
+    && window.Credential === undefined
+    && window.CredentialsContainer === undefined
+    && window.DeviceMotionEvent !== undefined
+    && window.DeviceOrientationEvent !== undefined
+    && navigator.maxTouchPoints === 5
+    && navigator.plugins.length === 0
+    && navigator.platform !== "iPhone"
+    && typeof navigator.standalone !== "undefined"
+    
     const android = /(Android);?[\s/]+([\d.]+)?/.test(ua)
-    const ios = iphone || ipad
+    const ios = iphone || ipad || isIPadOs
 
     return { ios, android }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bug fix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

You have tested in the following platforms:

- [x] PC
- [x] iOS
- [x] Android

Providing a reproduction demo will be better(you can pick a platform below and **fork** the demo):

**Other information:**

Since iOS 13, the iPad Pro runs under iPadOS and does not identify itself as a iDevice anymore. There have been a lot of approaches to identify an iPadOS but they all are not failsafe. My current method taken from https://stackoverflow.com/questions/57765958/how-to-detect-ipad-and-ipad-os-version-in-ios-13-and-up/59049628 has been pretty good and so far failsafe on iPadOS 13 and 14.

Things might change when Apple will release a touch display anytime in the future, but for know, this check adds solid detection for all iPad (Pros) running iPadOS 13.
Fixes issues on iPad.

The check `&& typeof navigator.standalone !== "undefined"` is only true on Safari MAC, since its the only browser that uses navigator.standalone, so this check also should be safe in the future, when touch displays enter the market. Since I use BSL in every project, I have a tight eye on regressions and will continue to update.